### PR TITLE
refactor(core): centralize loader helpers into inc/core/loader.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,21 +7,6 @@ if (!defined('ABSPATH')) exit;
 if (!defined('LD_THEME_DIR')) define('LD_THEME_DIR', get_stylesheet_directory());
 if (!defined('LD_THEME_URI')) define('LD_THEME_URI',  get_stylesheet_directory_uri());
 
-/** Безопасные инклюды — доступны уже в functions.php */
-if (!function_exists('ld_require_once_safe')) {
-  function ld_require_once_safe(string $file): void {
-    if (is_file($file)) require_once $file;
-  }
-}
-if (!function_exists('ld_require_dir')) {
-  function ld_require_dir(string $dir): void {
-    if (!is_dir($dir)) return;
-    foreach (glob(trailingslashit($dir) . '*.php') as $file) {
-      if (basename($file) === 'index.php') continue;
-      require_once $file;
-    }
-  }
-}
-
 /** Точка входа темы */
-ld_require_once_safe(LD_THEME_DIR . '/inc/bootstrap.php');
+$bootstrap = LD_THEME_DIR . '/inc/bootstrap.php';
+if (is_file($bootstrap)) require_once $bootstrap;

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -11,17 +11,7 @@ if (!defined('ABSPATH')) exit;
  * 4) nav & widgets
  */
 
-if (!function_exists('ld_require_once_safe') || !function_exists('ld_require_dir')) {
-  // страховка на случай, если файл подключили напрямую (в норме эти функции уже есть из functions.php)
-  function ld_require_once_safe(string $file): void { if (is_file($file)) require_once $file; }
-  function ld_require_dir(string $dir): void {
-    if (!is_dir($dir)) return;
-    foreach (glob(trailingslashit($dir) . '*.php') as $file) {
-      if (basename($file) === 'index.php') continue;
-      require_once $file;
-    }
-  }
-}
+require_once __DIR__ . '/core/loader.php';
 
 add_action('after_setup_theme', function () {
   $base = get_stylesheet_directory();

--- a/inc/core/loader.php
+++ b/inc/core/loader.php
@@ -1,0 +1,18 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+if (!function_exists('ld_require_once_safe')) {
+  function ld_require_once_safe(string $file): void {
+    if (is_file($file)) require_once $file;
+  }
+}
+if (!function_exists('ld_require_dir')) {
+  function ld_require_dir(string $dir): void {
+    if (!is_dir($dir)) return;
+    foreach (glob(trailingslashit($dir) . '*.php') as $file) {
+      if (basename($file) === 'index.php') continue;
+      require_once $file;
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- centralize loader helpers in `inc/core/loader.php`
- load loader helpers from `inc/bootstrap.php`
- simplify `functions.php` bootstrap include

## Testing
- `npm test` *(fails: Missing script: "test")*
- `php -l functions.php inc/bootstrap.php inc/core/loader.php`


------
https://chatgpt.com/codex/tasks/task_e_68c14789327c8330a3693a0caff34fde