### PR TITLE
feat(icons-admin): inline sprite and live ACF icon previews

### DIFF
--- a/acf-json/post-icon.json
+++ b/acf-json/post-icon.json
@@ -4,11 +4,11 @@
     "fields": [
         {
             "key": "field_post_icon_name",
-            "label": "Content Icon",
+            "label": "Icon (library)",
             "name": "post_icon_name",
             "aria-label": "",
             "type": "select",
-            "instructions": "",
+            "instructions": "Choose from theme icon set. Takes priority over upload.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -27,6 +27,32 @@
             "placeholder": "",
             "create_options": 0,
             "save_options": 0
+        },
+        {
+            "key": "field_post_icon_media",
+            "label": "Custom Icon (upload)",
+            "name": "term_icon_media",
+            "aria-label": "",
+            "type": "image",
+            "instructions": "SVG or PNG. Used only if no library icon selected.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "return_format": "id",
+            "library": "all",
+            "min_width": "",
+            "min_height": "",
+            "min_size": "",
+            "max_width": "",
+            "max_height": "",
+            "max_size": "",
+            "mime_types": "",
+            "allow_in_bindings": 0,
+            "preview_size": "medium"
         }
     ],
     "location": [
@@ -49,6 +75,13 @@
                 "param": "post_type",
                 "operator": "==",
                 "value": "modeling"
+            }
+        ],
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "page"
             }
         ]
     ],

--- a/acf-json/term-icon.json
+++ b/acf-json/term-icon.json
@@ -4,11 +4,11 @@
     "fields": [
         {
             "key": "field_term_icon_name",
-            "label": "Content Icon",
+            "label": "Icon (library)",
             "name": "term_icon_name",
             "aria-label": "",
             "type": "select",
-            "instructions": "",
+            "instructions": "Choose from theme icon set. Takes priority over upload.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -30,11 +30,11 @@
         },
         {
             "key": "field_term_icon_media",
-            "label": "Fallback Image",
+            "label": "Custom Icon (upload)",
             "name": "term_icon_media",
             "aria-label": "",
             "type": "image",
-            "instructions": "",
+            "instructions": "SVG or PNG. Used only if no library icon selected.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {

--- a/assets/admin/icon-preview.css
+++ b/assets/admin/icon-preview.css
@@ -1,10 +1,13 @@
-.ld-icon-preview {
-  display: inline-block;
-  vertical-align: middle;
-  margin-left: 4px;
+.acf-field[data-name="menu_icon"] .acf-input,
+.acf-field[data-name="post_icon_name"] .acf-input,
+.acf-field[data-name="term_icon_name"] .acf-input {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
-.ld-icon-preview .icon {
-  width: 1em;
-  height: 1em;
+.icon-preview {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
 }

--- a/assets/admin/icon-preview.js
+++ b/assets/admin/icon-preview.js
@@ -1,22 +1,19 @@
 (function(){
-  function init(){
-    var names=['menu_icon','post_icon_name','term_icon_name'];
-    names.forEach(function(name){
-      document.querySelectorAll('.acf-field[data-name="'+name+'"]').forEach(function(field){
-        var select=field.querySelector('select');
-        if(!select)return;
-        var preview=document.createElement('span');
-        preview.className='ld-icon-preview';
-        select.insertAdjacentElement('afterend',preview);
-        function render(){
-          var val=select.value;
-          preview.innerHTML=val?'<svg class="icon"><use href="#'+val+'"></use></svg>':'';
-        }
-        select.addEventListener('change',render);
-        render();
-      });
-    });
+  function mount(select){
+    if(!select) return;
+    const wrap = select.closest('.acf-input'); if(!wrap) return;
+    let holder = wrap.querySelector('.icon-preview');
+    if(!holder){ holder = document.createElement('span'); holder.className='icon-preview'; wrap.prepend(holder); }
+    const val = select.value; // full id, e.g. "icon-ui-menu"
+    holder.innerHTML = val ? `<svg aria-hidden="true"><use href="#${val}"></use></svg>` : '';
   }
-  if(document.readyState!=='loading')init();
-  else document.addEventListener('DOMContentLoaded',init);
+  function init(){
+    const qs = [
+      '.acf-field[data-name="menu_icon"] select',
+      '.acf-field[data-name="post_icon_name"] select',
+      '.acf-field[data-name="term_icon_name"] select'
+    ].join(',');
+    document.querySelectorAll(qs).forEach(s => { mount(s); s.addEventListener('change', ()=>mount(s)); });
+  }
+  if (document.readyState!=='loading') init(); else document.addEventListener('DOMContentLoaded', init);
 })();

--- a/docs/ICON_SYSTEM.md
+++ b/docs/ICON_SYSTEM.md
@@ -10,3 +10,58 @@ Tracking integration of a unified icon system.
 ## Goal
 Migrate to structured `assets/icons/src` with a generated `sprite.svg` and ACF integration.
 
+## Admin Integration — kickoff
+
+### Current state
+- Sprite build pipeline is in place (`assets/icons/src` → `assets/icons/sprite.svg`).
+- ACF fields exist for terms, posts, and menus but need polish (preview, labels, priority).
+
+### Goal
+- Enable preview in WP admin for icon selects.
+- Support dual source for terms: library (sprite) + custom upload (SVG/PNG) with clear priority.
+- Inject menu icons on frontend.
+
+### Acceptance criteria
+- [x] Sprite inlined on admin pages.
+- [x] Live preview beside ACF selects (`menu_icon`, `post_icon_name`, `term_icon_name`).
+- [x] Terms: Select (library) overrides Upload (fallback image).
+- [x] Category/Tag list shows "Icon" column.
+- [x] Menu items render chosen icon before label on frontend.
+- [x] Docs updated for editors (how to use).
+
+Admin list "Icon" columns are fixed at 28px wide (24px glyph + 4px left padding), and the preview assets scope themselves to ACF icon fields via their `data-name` attributes.
+
+### Helpers
+
+Render the current taxonomy term's icon at the default size (24px); sprite selection overrides upload:
+
+```php
+echo ld_term_icon_html();
+```
+
+Output a larger post or page icon (32px) and fall back to an uploaded image when no library icon is chosen:
+
+```php
+ld_content_icon( null, [ 'class' => 'icon--32' ] );
+```
+
+### How to use in WP Admin
+
+- **Categories/Tags:** pick **Icon (library)** or upload **Custom Icon**; the library choice overrides the upload.
+- **Menus:** open the menu item and set the **Menu Icon** field.
+- **Preview:** a small icon appears next to the select; if you don't see it, reload the page.
+
+### Examples for Pages
+
+In a page header:
+
+```php
+echo ld_content_icon(null, ['class' => 'icon']);
+```
+
+Inside loops (e.g., page list):
+
+```php
+echo ld_content_icon(get_the_ID(), ['class' => 'icon icon--24']);
+```
+

--- a/inc/extensions/icon-system.php
+++ b/inc/extensions/icon-system.php
@@ -1,66 +1,202 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if (! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 // inc/extensions/icon-system.php
 // Helpers and admin integration for SVG sprite icons.
 
-if (!function_exists('ld_sprite_path')) {
-  function ld_sprite_path(): string {
-    return get_stylesheet_directory() . '/assets/icons/sprite.svg';
-  }
-}
-
-if (!function_exists('ld_sprite_choices')) {
-  function ld_sprite_choices(): array {
-    $file = ld_sprite_path();
-    if (!is_file($file)) return [];
-    $svg = file_get_contents($file);
-    if (!$svg) return [];
-    preg_match_all('/<symbol[^>]+id="([^"]+)"/i', $svg, $m);
-    $choices = [];
-    foreach ($m[1] ?? [] as $id) {
-      $choices[$id] = $id;
+if ( ! function_exists( 'ld_sprite_path' ) ) {
+    function ld_sprite_path(): string {
+        return get_stylesheet_directory() . '/assets/icons/sprite.svg';
     }
-    return $choices;
-  }
 }
 
-if (!function_exists('ld__sprite_load_field')) {
-  function ld__sprite_load_field($field) {
-    $field['choices'] = ld_sprite_choices();
-    return $field;
-  }
+if ( ! function_exists( 'ld_sprite_choices_full' ) ) {
+    function ld_sprite_choices_full(): array {
+        static $choices;
+
+        if ( isset( $choices ) ) {
+            return $choices;
+        }
+
+        $file = ld_sprite_path();
+        if ( ! is_file( $file ) ) {
+            return [];
+        }
+
+        $svg = file_get_contents( $file );
+        if ( ! $svg ) {
+            return [];
+        }
+
+        preg_match_all( '/<symbol[^>]+id="([^"]+)"/i', $svg, $matches );
+        $choices = [];
+        foreach ( $matches[1] ?? [] as $id ) {
+            $choices[ $id ] = $id;
+        }
+
+        return $choices;
+    }
 }
 
-add_filter('acf/load_field/name=menu_icon', 'ld__sprite_load_field');
-add_filter('acf/load_field/name=post_icon_name', 'ld__sprite_load_field');
-add_filter('acf/load_field/name=term_icon_name', 'ld__sprite_load_field');
+if ( ! function_exists( 'ld__sprite_load_field_full' ) ) {
+    function ld__sprite_load_field_full( $field ) {
+        $field['choices'] = ld_sprite_choices_full();
+        $field['ui']      = 1;
 
-add_action('admin_enqueue_scripts', function () {
-  $dir = get_stylesheet_directory();
-  $uri = get_stylesheet_directory_uri();
-  wp_enqueue_style('ld-icon-preview', $uri . '/assets/admin/icon-preview.css', [], filemtime($dir . '/assets/admin/icon-preview.css'));
-  wp_enqueue_script('ld-icon-preview', $uri . '/assets/admin/icon-preview.js', [], filemtime($dir . '/assets/admin/icon-preview.js'), true);
+        return $field;
+    }
+}
+
+add_filter( 'acf/load_field/name=menu_icon', 'ld__sprite_load_field_full' );
+add_filter( 'acf/load_field/name=post_icon_name', 'ld__sprite_load_field_full' );
+add_filter( 'acf/load_field/name=term_icon_name', 'ld__sprite_load_field_full' );
+
+add_action( 'admin_enqueue_scripts', function () {
+    wp_enqueue_style( 'ld-icon-preview', get_stylesheet_directory_uri() . '/assets/admin/icon-preview.css', [], null );
+    wp_enqueue_script( 'ld-icon-preview', get_stylesheet_directory_uri() . '/assets/admin/icon-preview.js', [], null, true );
+} );
+
+add_action( 'admin_footer', function () {
+    $file = ld_sprite_path();
+    if ( ! is_file( $file ) ) {
+        return;
+    }
+
+    $svg = file_get_contents( $file );
+    if ( ! $svg ) {
+        return;
+    }
+
+    echo '<div style="display:none" class="ld-admin-sprite">' . $svg . '</div>';
+} );
+
+add_action(
+    'admin_head',
+    function () {
+        echo '<style>
+        .wp-list-table .column-icon{width:28px}
+        .wp-list-table td.column-icon{padding-left:4px;padding-right:0;text-align:center}
+        .wp-list-table td.column-icon .icon{width:24px;height:24px;display:inline-block}
+        </style>';
+    }
+);
+
+add_filter('upload_mimes', function($m){
+    if (current_user_can('manage_options')) $m['svg'] = 'image/svg+xml';
+    return $m;
 });
 
-add_filter('walker_nav_menu_start_el', function ($item_output, $item, $depth, $args) {
-  if (!function_exists('get_field')) return $item_output;
-  $icon = get_field('menu_icon', $item);
-  if (!$icon) return $item_output;
-  $svg = ld_icon($icon, 'menu__icon');
-  return preg_replace('/(<a[^>]*>)/', '$1' . $svg, $item_output, 1);
-}, 10, 4);
+add_filter( 'walker_nav_menu_start_el', function ( $item_output, $item, $depth, $args ) {
+    if ( ! function_exists( 'get_field' ) ) {
+        return $item_output;
+    }
 
-add_filter('manage_edit-category_columns', function ($cols) {
-  $cols['ld_icon'] = __('Icon', 'ld');
-  return $cols;
-});
+    $icon = get_field( 'menu_icon', $item );
+    if ( ! $icon ) {
+        return $item_output;
+    }
 
-add_filter('manage_category_custom_column', function ($out, $col, $term_id) {
-  if ($col !== 'ld_icon') return $out;
-  $icon = function_exists('get_field') ? get_field('term_icon_name', 'term_' . $term_id) : '';
-  if ($icon) return ld_icon($icon);
-  $media = function_exists('get_field') ? (int) get_field('term_icon_media', 'term_' . $term_id) : 0;
-  if ($media) return ld_image_or_svg_html($media, 'thumbnail', ['class' => 'icon']);
-  return '';
-}, 10, 3);
+    $svg = ld_icon( $icon, '', [ 'class' => 'menu__icon' ] );
+
+    return preg_replace( '/(<a[^>]*>)/', '$1' . $svg, $item_output, 1 );
+}, 10, 4 );
+
+if ( ! function_exists( 'ld_term_icon_html' ) ) {
+    /**
+     * Render a term icon, preferring sprite selections over uploaded images.
+     *
+     * @param int|WP_Term|null $term  Term ID or object. Falls back to the queried term.
+     * @param string           $class Optional additional class names.
+     * @param array            $attrs Extra attributes for the rendered tag.
+     */
+    function ld_term_icon_html( $term = null, string $class = '', array $attrs = [] ): string {
+        if ( ! function_exists( 'get_field' ) ) {
+            return '';
+        }
+
+        if ( ! $term && ( is_tax() || is_category() || is_tag() ) ) {
+            $term = get_queried_object();
+        }
+
+        if ( $term instanceof WP_Term ) {
+            $term_id = (int) $term->term_id;
+        } else {
+            $term_id = (int) $term;
+        }
+
+        if ( ! $term_id ) {
+            return '';
+        }
+
+        $attrs['class'] = trim( 'icon ' . $class . ' ' . ( $attrs['class'] ?? '' ) );
+
+        $name = get_field( 'term_icon_name', 'term_' . $term_id );
+        if ( $name ) {
+            return ld_icon( $name, '', $attrs );
+        }
+
+        $id = (int) get_field( 'term_icon_media', 'term_' . $term_id );
+        if ( $id ) {
+            return ld_image_or_svg_html( $id, 'full', $attrs );
+        }
+
+        return '';
+    }
+}
+
+add_filter( 'manage_edit-category_columns', fn( $cols ) => [ 'icon' => __( 'Icon', 'ld' ) ] + $cols );
+add_filter(
+    'manage_category_custom_column',
+    function ( $out, $col, $term_id ) {
+        if ( 'icon' !== $col ) {
+            return $out;
+        }
+
+        $html = ld_term_icon_html( $term_id );
+
+        return $html ?: '—';
+    },
+    10,
+    3
+);
+
+add_filter( 'manage_edit-post_tag_columns', fn( $cols ) => [ 'icon' => __( 'Icon', 'ld' ) ] + $cols );
+add_filter(
+    'manage_post_tag_custom_column',
+    function ( $out, $col, $term_id ) {
+        if ( 'icon' !== $col ) {
+            return $out;
+        }
+
+        $html = ld_term_icon_html( $term_id );
+
+        return $html ?: '—';
+    },
+    10,
+    3
+);
+
+add_filter(
+    'manage_page_posts_columns',
+    function ( $cols ) {
+        $new = [ 'icon' => __( 'Icon', 'ld' ) ];
+
+        return array_slice( $cols, 0, 1, true ) + $new + array_slice( $cols, 1, null, true );
+    }
+);
+add_action(
+    'manage_page_posts_custom_column',
+    function ( $col, $post_id ) {
+        if ( 'icon' !== $col ) {
+            return;
+        }
+
+        echo function_exists( 'ld_content_icon' )
+            ? ld_content_icon( $post_id, [ 'class' => 'icon' ] )
+            : '';
+    },
+    10,
+    2
+);

--- a/inc/helpers/icons-content.php
+++ b/inc/helpers/icons-content.php
@@ -1,0 +1,32 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! function_exists( 'ld_content_icon' ) ) {
+    /**
+     * Return a content icon, preferring sprite selections over uploads.
+     *
+     * @param int|null $post_id Optional post ID. Defaults to current post.
+     * @param array    $attrs   Additional attributes for the rendered tag.
+     *
+     * @return string SVG or image HTML.
+     */
+    function ld_content_icon( $post_id = null, array $attrs = [] ): string {
+        $post_id = $post_id ?: get_the_ID();
+
+        if ( ! $post_id ) {
+            return '';
+        }
+
+        $name = function_exists( 'get_field' ) ? (string) get_field( 'post_icon_name', $post_id ) : '';
+        if ( $name && function_exists( 'ld_icon' ) ) {
+            return ld_icon( $name, '', $attrs );
+        }
+
+        $img_id = function_exists( 'get_field' ) ? (int) get_field( 'term_icon_media', $post_id ) : 0;
+
+        return ld_image_or_svg_html( $img_id, 'full', $attrs );
+    }
+}
+

--- a/inc/helpers/ld-site-config-helpers.php
+++ b/inc/helpers/ld-site-config-helpers.php
@@ -94,10 +94,3 @@ if (!function_exists('ld_copyright')) {
   }
 }
 
-// Allow SVG upload for admins (free & safe-ish)
-add_filter('upload_mimes', function ($mimes) {
-  if (current_user_can('manage_options')) {
-    $mimes['svg'] = 'image/svg+xml';
-  }
-  return $mimes;
-});

--- a/style.css
+++ b/style.css
@@ -9,12 +9,14 @@ Theme through 1111 Проверячем бигмак
 .icon {
   display: inline-block;
   vertical-align: middle;
-  width: 1em;
-  height: 1em;
+  width: 24px;
+  height: 24px;
   fill: currentColor;
 }
 
-.icon--sm { font-size: 14px; }
-.icon--md { font-size: 18px; }
-.icon--lg { font-size: 24px; }
-.icon--xl { font-size: 32px; }
+.icon--12 { width: 12px; height: 12px; }
+.icon--16 { width: 16px; height: 16px; }
+.icon--20 { width: 20px; height: 20px; }
+.icon--24 { width: 24px; height: 24px; } /* явная утилита */
+.icon--32 { width: 32px; height: 32px; }
+.icon--40 { width: 40px; height: 40px; }


### PR DESCRIPTION
## Summary
- expose `ld_term_icon_html()` helper so taxonomy templates and admin lists render sprite icons before uploaded images
- display an "Icon" column on category, tag, and page admin screens using the helper and a 20px size utility
- inline SVG sprite in admin and provide live previews beside ACF icon selects
- expand `ld_term_icon_html()` to accept a term object or fall back to the queried term for easier template usage
- allow administrators to upload SVG files for icon fallbacks
- clarify term icon field labels and help text so editors know library icons take priority over uploads
- track completed admin integration tasks, document helper usage, and add an editor guide with preview and priority rules
- enable Content Icon fields on pages with an upload fallback and introduce `ld_content_icon()` to render icons for posts and pages
- return HTML from `ld_content_icon()` so templates control output
- refine Pages list icon column placement and preview sizing
- default `.icon` to 24×24 and provide utility classes for 12, 16, 20, 24, 32, and 40px sizes
- document how to render `ld_content_icon()` in page headers and loops
- merge classes into attrs for `ld_term_icon_html()` and pass attrs to icon/image helpers
- inject menu icons using `ld_icon()` with an attribute array
- target admin preview selects via data-name and scope their flex styles
- narrow Icon columns to 28px and center 24px icons across taxonomy and page admin tables
- document 28 px admin column width and that previews are scoped via ACF `data-name` selectors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3f393b238833087a30835ea39ea49