### PR TITLE
feat(site-settings): add toggle to enable Page Color UI in Features tab

### DIFF
--- a/acf-json/site-settings.json
+++ b/acf-json/site-settings.json
@@ -99,6 +99,16 @@
       "ui": 1
     },
     {
+      "key": "field_enable_page_color",
+      "label": "Enable Page Color UI",
+      "name": "enable_page_color_ui",
+      "type": "true_false",
+      "ui": 1,
+      "default_value": 1,
+      "wrapper": { "width": "", "class": "", "id": "" },
+      "parent_layout": "layout_features"
+    },
+    {
       "key": "field_tab_footer",
       "label": "Footer",
       "name": "",
@@ -129,5 +139,5 @@
   "position": "normal",
   "style": "default",
   "title": "Site Settings",
-  "modified": 1757753322
+  "modified": 1757850662
 }


### PR DESCRIPTION
## Summary
- add an Enable Page Color UI toggle in Site Settings Features tab

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ac07f430833099d184a7ef53b104