### PR TITLE
Revise icon system doc for content icon usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,20 @@ WordPress theme codebase for Lowdesign projects.
 
 ## Documentation
 
+### Core references
+- [Overview](docs/overview.md)
 - [Architecture overview](docs/ARCHITECTURE.md)
 - [Setup guide](docs/SETUP.md)
 - [Inventory](docs/INVENTORY.md)
+
+### Icon workflows
+- [Icon system](docs/icon-system.md)
+- [ACF field icons](docs/acf-field-icons.md)
+- [Icon sources](docs/icon-sources.md)
+- [Recipes](docs/recipes.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Changelog](docs/changelog.md)
+
+### Legacy references
+- [Original icon system notes](docs/ICON_SYSTEM.md)
 

--- a/docs/acf-field-icons.md
+++ b/docs/acf-field-icons.md
@@ -1,0 +1,36 @@
+# ACF Field Icons
+
+The theme exposes an "Icon" field group through Advanced Custom Fields (ACF) that lets editors pick icons for navigation, posts, and taxonomy terms. This document summarizes the field layout, UI copy, and expected behaviors so the experience stays consistent as we iterate.
+
+## Field group locations
+
+- **Site Settings:** Provides global icon overrides for navigation and footer components.
+- **Page and Post edit screens:** Allows per-entry icon selection that surfaces in list tables and cards.
+- **Taxonomy terms:** Supplies icon choices for categories, tags, or custom terms where iconography is part of the design language.
+
+## Field structure
+
+1. **Icon Source (Radio):** Options include "No icon," "Theme icon," and "Media Library."
+2. **Theme Icon (Select):** Populated from the sprite manifest; displays a live preview via JavaScript when an option is chosen.
+3. **Media Icon (File/Image):** Accepts SVG or PNG uploads. The field appears only when "Media Library" is selected.
+4. **Preview (Message field):** Mirrors the selected source and helps the editor confirm their choice.
+
+## Conditional logic
+
+- Choosing **No icon** hides both the sprite selector and media upload fields.
+- Choosing **Theme icon** reveals the sprite selector and preview while keeping the media upload hidden.
+- Choosing **Media Library** reveals the media upload and preview while hiding the sprite selector.
+
+## Data storage
+
+- Sprite selections store the icon slug (e.g., `ui/arrow-right`) for use with `ld_icon()` or inline SVG rendering.
+- Media uploads save the attachment ID so templates can fetch the corresponding image markup.
+- The icon source radio value should always be checked in templates before outputting markup.
+
+## Maintenance checklist
+
+- Confirm that new icons added to `assets/icons/src/` are registered in the ACF select choices.
+- Ensure translation strings for field labels and instructions live alongside other ACF field translations.
+- When duplicating field groups, keep the field keys stable to avoid data loss.
+
+For usage examples, see the [recipes collection](recipes.md) or the [icon source reference](icon-sources.md).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,17 @@
+# Changelog
+
+Track notable documentation updates and icon-system changes here. Follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions and date entries using ISO format.
+
+## [Unreleased]
+
+### Added
+- Initial documentation scaffold covering overview, icon system, ACF fields, icon sources, recipes, and troubleshooting.
+
+### Changed
+- _Nothing yet._
+
+### Fixed
+- _Nothing yet._
+
+### Removed
+- _Nothing yet._

--- a/docs/icon-sources.md
+++ b/docs/icon-sources.md
@@ -1,0 +1,34 @@
+# Icon Sources
+
+Editors can choose from three icon sources. Understanding how each option behaves ensures consistent rendering and prevents broken icons.
+
+## No icon
+
+- **Use when:** An item should intentionally display without accompanying iconography.
+- **Front-end result:** Templates skip icon markup entirely.
+- **Admin cues:** The preview panel shows "No icon selected" so editors understand nothing will render.
+- **Implementation note:** Always guard template icon output with a check for the source value.
+
+## Theme icon
+
+- **Use when:** A sprite icon from `assets/icons/src/` already covers the needed artwork.
+- **Front-end result:** Templates call `ld_icon( 'slug' )` or output inline SVG markup fetched from the compiled sprite.
+- **Admin cues:** Selecting a sprite reveals a live preview fed by the sprite manifest.
+- **Implementation note:** Slugs should follow the `set/name` pattern (e.g., `ui/check`) so they remain unique.
+
+## Media Library
+
+- **Use when:** A bespoke icon needs to be uploaded or the sprite is not yet updated.
+- **Front-end result:** Templates render the uploaded SVG/PNG using WordPress attachment helpers.
+- **Admin cues:** The file picker appears with the standard Media Library modal and the preview displays the uploaded asset.
+- **Implementation note:** Encourage SVG uploads for crisp rendering; PNG should be limited to photographic or gradient assets.
+
+## Fallback order
+
+Templates should respect the selection made in ACF. If legacy data only stored attachment IDs, the code should still prefer explicit choices in this order:
+
+1. Theme icon slug (sprite)
+2. Media Library attachment
+3. No icon (renders nothing)
+
+Refer to the [ACF field documentation](acf-field-icons.md) for field keys and JSON exports.

--- a/docs/icon-system.md
+++ b/docs/icon-system.md
@@ -1,0 +1,22 @@
+# Content Icon (Posts/Pages/Terms)
+
+## UI
+- **Icon source:** No icon / Theme icon / Media Library.
+- Theme icon → dropdown with sprite slugs (takes priority over upload).
+- Media Library → SVG only. Inline preview; can **Change** or **Remove** anytime.
+
+## Frontend access
+Stored meta:
+- Posts: `_ld_content_icon` → `{ source: 'none'|'theme'|'media', theme: string, media_id: number }`
+- Terms: `_ld_term_icon`   → same shape
+
+Example:
+```php
+$meta = get_post_meta(get_the_ID(), '_ld_content_icon', true);
+
+if (($meta['source'] ?? '') === 'theme' && !empty($meta['theme'])) {
+  echo '<svg class="icon"><use href="#'.esc_attr($meta['theme']).'"></use></svg>';
+} elseif (($meta['source'] ?? '') === 'media' && !empty($meta['media_id'])) {
+  echo wp_get_attachment_image((int) $meta['media_id'], 'full');
+}
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,23 @@
+# Lowdesign — Admin Icons & ACF Field Icons (Overview)
+
+**Goal:** единая икон-система в админке + возможность привязывать иконку к каждому ACF-полю. Минимум кода, предсказуемый UX.
+
+## What you get
+- Consistent admin previews (24×24 box, 18×18 glyph).
+- Content Icon control for Posts/Pages/Terms (Theme icon / Media Library).
+- ACF “Field Icon” — choose an icon per field (multi-source: sprite, cpt, ui, brand).
+- Frontend helpers to render the chosen icon.
+
+## Files (key)
+- `assets/admin/icon-preview.css` — общий стиль превью/бейджей.
+- `assets/admin/icon-preview.js` — sprite + media inline preview, не ломает ACF-кнопки.
+- `assets/admin/acf-field-icons.js` — рисует маленькие иконки рядом с label полей (admin).
+- `assets/admin/acf-field-icon-setting-preview.js` — превью иконки справа от select в настройке ACF.
+- `inc/extensions/icon-system.php` — контрол Content Icon (источник/превью/сохранение).
+- `inc/extensions/acf-field-icons.php` — настройка для ACF-полей + multi-source каталог.
+- `assets/icons/src/{cpt,ui,brand}/*.svg` — inline наборы.
+
+## Conventions
+- Preview box: **24×24**, glyph: **18×18**, `fill: currentColor`.
+- Radio focus: доступность через `:focus-visible`.
+- We never hide `.image-wrap` → ACF buttons (Remove/Edit/Replace) always visible.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,36 @@
+# Recipes
+
+Common workflows for maintaining the icon system and related theme features.
+
+## Add a new icon to the sprite
+
+1. Save the SVG into `assets/icons/src/<set>/<name>.svg`.
+2. Ensure the SVG includes a `<title>` element for accessibility.
+3. Run `npm run build` (or `npm run dev` while developing) to regenerate the sprite.
+4. Update the ACF select field choices if editors need to pick the new icon.
+5. Reference the icon in templates using `ld_icon( '<set>/<name>' )`.
+
+## Swap an icon in an existing component
+
+1. Confirm the target component uses `ld_icon()` or inline sprite references.
+2. Update the component markup to point to the new icon slug.
+3. Test the component in Storybook or the block editor preview to verify sizing and alignment.
+4. Communicate the change to editors if the new icon alters meaning.
+
+## Provide a fallback media icon
+
+1. Open the relevant post, page, or term in the WordPress admin.
+2. In the Icon field group, choose **Media Library**.
+3. Upload the fallback SVG/PNG or select an existing attachment.
+4. Publish or update the entry to save the attachment reference.
+5. Confirm the front end renders the uploaded icon instead of the sprite entry.
+
+## Clean up unused icons
+
+1. Audit icon usage across templates and ACF configurations.
+2. Remove unused SVG files from `assets/icons/src/`.
+3. Update the sprite by running `npm run build`.
+4. Delete orphaned choices in ACF field definitions.
+5. Verify no templates reference the removed icon slugs before committing.
+
+More edge-case handling lives in [Troubleshooting](troubleshooting.md). For the underlying architecture, refer to the [icon system guide](icon-system.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,30 @@
+# Troubleshooting
+
+Guidance for diagnosing common issues related to the icon workflow and theme build process.
+
+## Sprite icon not appearing on the front end
+
+- Confirm the icon slug stored in ACF matches an SVG file in `assets/icons/src/`.
+- Re-run `npm run build` to regenerate the sprite after adding new icons.
+- Ensure the deployed environment received the updated `assets/icons/src/` files; the sprite itself is generated at build time.
+- Inspect the rendered markup to verify that `use` tags point to an existing symbol ID.
+
+## Media Library icon renders as a large image
+
+- Check that the attachment markup includes explicit `width` and `height` attributes that match the icon utility classes.
+- Add or adjust CSS in `assets/src/scss/utilities/_icons.scss` to constrain image-based icons if they must remain raster formats.
+- Consider converting the asset to SVG if crispness or scaling remains problematic.
+
+## Editors do not see icon preview updates
+
+- Verify that the admin JavaScript responsible for preview updates is enqueued via the relevant ACF hooks.
+- Confirm that `acf-json/` exports are in sync with the active site; re-export if field keys changed.
+- Clear the browser cache or disable aggressive caching plugins that may block the admin script.
+
+## Build command fails after adding icons
+
+- Lint the SVG with `npm run lint:icons` (if available) to catch malformed markup.
+- Look for XML declarations or embedded raster images that the sprite generator cannot parse.
+- Validate that filenames use lowercase letters, numbers, and hyphens to avoid path resolution issues.
+
+For process guidance see the [recipes](recipes.md), and review [icon sources](icon-sources.md) to confirm the selected fallback behavior.


### PR DESCRIPTION
## Summary
- rewrite the icon system documentation to focus on the content icon controls for posts, pages, and terms
- document the stored meta structure for theme and media sources with a frontend rendering example

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68c94d52f5bc8330938b55845794de4b